### PR TITLE
feat: rename call -> setenv

### DIFF
--- a/example/shell/src/main.rs
+++ b/example/shell/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
 
     child_stdin.write_all("echo \"initial:${SOME_ENV_VAR}\"\n".as_bytes())?;
 
-    env_injector.call("SOME_ENV_VAR", "injected_value")
+    env_injector.setenv("SOME_ENV_VAR", "injected_value")
         .context("injecting new env var value")?;
 
     child_stdin.write_all("echo \"injected:${SOME_ENV_VAR}\"\n".as_bytes())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@ impl EnvInjector {
         })
     }
 
-    pub fn call(&self, key: &str, value: &str) -> Result<(), Error> {
+    /// Call setenv in the child process.
+    pub fn setenv(&self, key: &str, value: &str) -> Result<(), Error> {
         // The user might call the shim immediately after launching the program,
         // in which case the control socket might not be up yet. Use an
         // exponential backoff to poll until the control socket comes up.


### PR DESCRIPTION
I think using `setenv` allows for more API
growth because it will let us add other
environment variable manipulation RPCs
if we need to in the future.

Not a breaking change since we have not released
yet.