### PR TITLE
fix: remove __NonExhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@ pub enum Error {
     Err {
         msg: String,
     },
-    __NonExhaustive,
 }
 
 impl std::fmt::Display for Error {


### PR DESCRIPTION
As pointed out in #1, this is redundant.